### PR TITLE
アンドロイドビルドができない不具合の修正

### DIFF
--- a/packages/mottai_flutter_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/mottai_flutter_app/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.kosukesaigusa.mottai_flutter_app">
    <application
-        android:label="mottai_flutter_app"
-        android:icon="@mipmap/ic_launcher">
+        android:label="mottai_flutter_app">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Issue
なし


## 説明
アンドロイドのビルドが、以下のエラーで失敗していました。
```bash
 error: resource mipmap/ic_launcher (aka com.kosukesaigusa.mottai_flutter_app:mipmap/ic_launcher) not found.
```

調査したところiconファイルを参照しようとしているが、見つかっていないためのようでした。
そのため、以下の記述を削除してiconファイルの参照を行わないようにしました。
```xml
<!-- AndroidManifest.xml -->
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
    package="com.kosukesaigusa.mottai_flutter_app">
   <application
        android:label="mottai_flutter_app">
    <!--    android:icon="@mipmap/ic_launcher" を削除 -->

```

## その他
なし

## チェックリスト

- [ ] PR の冒頭に関連する Issue 番号を記載しましたか？
- [x] 本 PR の変更に関して、エディタや IDE で意図しない警告は増えていませんか？（lint 警告やタイポなど）
- [ ] Issue の完了の定義は満たせていますか？
