### PR TITLE
FirebaseStorageServiceクラスを実装

### DIFF
--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -4,7 +4,12 @@ import 'package:firebase_storage/firebase_storage.dart';
 
 import 'firebase_storage_resource.dart';
 
+/// Firebase Storageとのインタラクションを提供するサービスクラス。
 class FirebaseStorageService {
+  /// カスタムの [bucket] を使用して、新しい [FirebaseStorageService] のインスタンスを作成する。
+  ///
+  /// [bucket] が指定された場合、そのバケットが使用される。
+  /// そうでない場合、デフォルトのバケットが使用される。
   FirebaseStorageService({String? bucket}) {
     if (bucket != null) {
       _firebaseStorage = FirebaseStorage.instanceFor(bucket: bucket);
@@ -14,6 +19,9 @@ class FirebaseStorageService {
   }
   late FirebaseStorage _firebaseStorage;
 
+  /// リソースをFirebase Storageに指定された [path] にアップロードする。
+  ///
+  /// [resource] パラメータは [FirebaseStorageResource] のインスタンスである必要がある。
   Future<String> upload({
     required String path,
     required FirebaseStorageResource resource,
@@ -30,16 +38,22 @@ class FirebaseStorageService {
     return imageRef.getDownloadURL();
   }
 
+  /// 指定された [path] のリソースのダウンロードURLを取得する。
   Future<String> getDownloadURL({required String path}) async {
     final imageRef = _firebaseStorage.ref().child(path);
     return imageRef.getDownloadURL();
   }
 
+  /// 指定された [path] のリソースを削除する。
   Future<void> delete({required String path}) async {
     final imageRef = _firebaseStorage.ref().child(path);
     return imageRef.delete();
   }
 
+  /// 指定された [path] のリソースのバイトデータを取得する。
+  ///
+  /// オプションの [byte] パラメータは、取得するバイト数の最大値を指定する。
+  /// デフォルトでは、1MB（1024 * 1024バイト）のデータが取得される。
   Future<Uint8List?> getData({
     required String path,
     int byte = 1024,
@@ -49,11 +63,17 @@ class FirebaseStorageService {
     return imageRef.getData(megaByte);
   }
 
+  /// 指定された [path] のすべてのリファレンス（ファイルとディレクトリ）を取得する。
   Future<ListResult> fetchAllReferences({required String path}) async {
     final storageRef = _firebaseStorage.ref().child(path);
     return storageRef.listAll();
   }
 
+  /// 指定された [path] のリファレンス（ファイルとディレクトリ）のリストを取得する。
+  /// オプションで [maxResults] と [pageToken] の使用が可能。
+  ///
+  /// [maxResults] は、取得する結果の最大数を指定する。
+  /// [pageToken] は、次のセットの結果を取得するためのページネーションに使用される。
   Future<ListResult> fetchList({
     required String path,
     int maxResults = 100,

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -22,4 +22,9 @@ class FirebaseStorageService {
     final imageRef = _firebaseStorage.ref().child(path);
     return imageRef.getDownloadURL();
   }
+
+  Future<void> delete({required String path}) async {
+    final imageRef = _firebaseStorage.ref().child(path);
+    return imageRef.delete();
+  }
 }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -1,6 +1,6 @@
-import 'dart:io';
-
 import 'package:firebase_storage/firebase_storage.dart';
+
+import 'firebase_storage_resource.dart';
 
 class FirebaseStorageService {
   FirebaseStorageService({String? bucket}) {
@@ -12,9 +12,19 @@ class FirebaseStorageService {
   }
   late FirebaseStorage _firebaseStorage;
 
-  Future<String> upload({required String path, required File file}) async {
+  Future<String> upload({
+    required String path,
+    required FirebaseStorageResource resource,
+  }) async {
     final imageRef = _firebaseStorage.ref().child(path);
-    await imageRef.putFile(file);
+    switch (resource) {
+      case FirebaseStorageFile():
+        await imageRef.putFile(resource.file);
+      case FirebaseStorageUrl():
+        await imageRef.putString(resource.url);
+      case FirebaseStorageRawData():
+        await imageRef.putData(resource.data);
+    }
     return imageRef.getDownloadURL();
   }
 

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -17,4 +17,9 @@ class FirebaseStorageService {
     await imageRef.putFile(file);
     return imageRef.getDownloadURL();
   }
+
+  Future<String> getDownloadURL({required String path}) async {
+    final imageRef = _firebaseStorage.ref().child(path);
+    return imageRef.getDownloadURL();
+  }
 }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -3,13 +3,11 @@ import 'dart:io';
 import 'package:firebase_storage/firebase_storage.dart';
 
 class FirebaseStorageService {
-  FirebaseStorageService({required String path}) {
-    _reference = FirebaseStorage.instance.ref().child(path);
-  }
-  late Reference _reference;
+  final Reference _reference = FirebaseStorage.instance.ref();
 
-  Future<String> upload(File file) async {
-    await _reference.putFile(file);
-    return _reference.getDownloadURL();
+  Future<String> upload({required String path, required File file}) async {
+    final imageRef = _reference.child(path);
+    await imageRef.putFile(file);
+    return imageRef.getDownloadURL();
   }
 }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:firebase_storage/firebase_storage.dart';
 
 import 'firebase_storage_resource.dart';
@@ -36,5 +38,14 @@ class FirebaseStorageService {
   Future<void> delete({required String path}) async {
     final imageRef = _firebaseStorage.ref().child(path);
     return imageRef.delete();
+  }
+
+  Future<Uint8List?> getData({
+    required String path,
+    int byte = 1024,
+  }) async {
+    final megaByte = byte * byte;
+    final imageRef = _firebaseStorage.ref().child(path);
+    return imageRef.getData(megaByte);
   }
 }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -3,10 +3,17 @@ import 'dart:io';
 import 'package:firebase_storage/firebase_storage.dart';
 
 class FirebaseStorageService {
-  final Reference _reference = FirebaseStorage.instance.ref();
+  FirebaseStorageService({String? bucket}) {
+    if (bucket != null) {
+      _firebaseStorage = FirebaseStorage.instanceFor(bucket: bucket);
+    } else {
+      _firebaseStorage = FirebaseStorage.instance;
+    }
+  }
+  late FirebaseStorage _firebaseStorage;
 
   Future<String> upload({required String path, required File file}) async {
-    final imageRef = _reference.child(path);
+    final imageRef = _firebaseStorage.ref().child(path);
     await imageRef.putFile(file);
     return imageRef.getDownloadURL();
   }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -48,4 +48,23 @@ class FirebaseStorageService {
     final imageRef = _firebaseStorage.ref().child(path);
     return imageRef.getData(megaByte);
   }
+
+  Future<ListResult> fetchAllReferences({required String path}) async {
+    final storageRef = _firebaseStorage.ref().child(path);
+    return storageRef.listAll();
+  }
+
+  Future<ListResult> fetchList({
+    required String path,
+    int maxResults = 100,
+    String? pageToken,
+  }) async {
+    final storageRef = _firebaseStorage.ref().child(path);
+    return storageRef.list(
+      ListOptions(
+        maxResults: maxResults,
+        pageToken: pageToken,
+      ),
+    );
+  }
 }

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage.dart
@@ -1,1 +1,15 @@
+import 'dart:io';
 
+import 'package:firebase_storage/firebase_storage.dart';
+
+class FirebaseStorageService {
+  FirebaseStorageService({required String path}) {
+    _reference = FirebaseStorage.instance.ref().child(path);
+  }
+  late Reference _reference;
+
+  Future<String> upload(File file) async {
+    await _reference.putFile(file);
+    return _reference.getDownloadURL();
+  }
+}

--- a/packages/firebase_common/lib/src/firebase_storage/firebase_storage_resource.dart
+++ b/packages/firebase_common/lib/src/firebase_storage/firebase_storage_resource.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+sealed class FirebaseStorageResource {}
+
+class FirebaseStorageFile extends FirebaseStorageResource {
+  FirebaseStorageFile(this.file);
+  final File file;
+}
+
+class FirebaseStorageUrl extends FirebaseStorageResource {
+  FirebaseStorageUrl(this.url);
+  final String url;
+}
+
+class FirebaseStorageRawData extends FirebaseStorageResource {
+  FirebaseStorageRawData(this.data);
+  final Uint8List data;
+}


### PR DESCRIPTION
## Issue

<!-- #100 のように issue 番号を記載してください（複数ある場合は複数書いてください） -->

close https://github.com/KosukeSaigusa/mottai-flutter-app/issues/37

## 説明
FirebaseStorageとのやりとりを行うサービスクラスを実装しました
- 作成したメソッドはサービスクラスのdoc commentを見ていただけると早いです！
- ファイルのアップロードには`File`や`String`、`Uint8List`などを共通で受け入れられるようにするため、`FirebaseStorageResouce`という`sealed class`を作成しました！

## UI

> packages/mottai_flutter_app/lib/development の下に適当なフォルダ・ファイルを作成して、そこで動作確認ができること（image_picker や wechat_assets_picker などの端末から画像を選択する類の機能は未実装なので、それを使わなくてもできる確認方法があればそれで済ませる。そうでなければ、端末から画像を選択する類の機能の実装を待つ必要があるかもしれないので相談する）

image_pickerなどを別で実装する必要があるためこのPRでは一旦実装していないです！
画像取得の機能が追加されたらUIを実装してみてサービスクラスが実際に使用可能かを試してみます！

## その他

参考
https://firebase.google.com/docs/storage/flutter/start?hl=ja

## チェックリスト

- [x] PR の冒頭に関連する Issue 番号を記載しましたか？
- [x] 本 PR の変更に関して、エディタや IDE で意図しない警告は増えていませんか？（lint 警告やタイポなど）
- [ ] Issue の完了の定義は満たせていますか？
