### PR TITLE
#78 画像詳細ビューをphotoViewパッケージに変更

### DIFF
--- a/packages/dart_flutter_common/lib/src/widgets/generic_image.dart
+++ b/packages/dart_flutter_common/lib/src/widgets/generic_image.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
 
 /// [GenericImage] で表示する画像の形状。
 enum ImageShape {
@@ -110,17 +111,12 @@ class GenericImage extends StatelessWidget {
           return Navigator.push<void>(
             context,
             MaterialPageRoute<void>(
-              builder: (context) => _ImageDetailView(
+              builder: (context) => // PhotoView(
+                  //   imageProvider: NetworkImage(imageUrl),
+                  // ),
+                  _ImageDetailView(
                 tag: tag,
-                child: _GenericCachedNetworkImage(
-                  imageUrl: imageUrl,
-                  imageShape: imageShape,
-                  size: size,
-                  width: width,
-                  height: height,
-                  borderRadius: borderRadius,
-                  loadingWidget: loadingWidget,
-                ),
+                imageUrl: imageUrl,
               ),
             ),
           );
@@ -302,43 +298,26 @@ class _Image extends StatelessWidget {
 class _ImageDetailView extends StatelessWidget {
   const _ImageDetailView({
     required this.tag,
-    required this.child,
+    required this.imageUrl,
   });
 
   final String tag;
-  final Widget child;
+  // final Widget child;
+  final String imageUrl;
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        GestureDetector(
-          onTap: () => Navigator.pop(context),
-          child: Scaffold(
-            floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
-            floatingActionButton: IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: () => Navigator.pop(context),
-            ),
-            body: Container(
-              height: MediaQuery.of(context).size.height,
-              width: MediaQuery.of(context).size.width,
-              decoration: const BoxDecoration(
-                color: Colors.black,
-              ),
-            ),
-          ),
-        ),
-        Center(
-          child: InteractiveViewer(
-            clipBehavior: Clip.none,
-            child: Hero(
-              tag: tag,
-              child: child,
-            ),
-          ),
-        ),
-      ],
+    return Scaffold(
+      floatingActionButtonLocation: FloatingActionButtonLocation.startTop,
+      floatingActionButton: IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: () => Navigator.pop(context),
+      ),
+      body: PhotoView(
+        imageProvider: NetworkImage(imageUrl),
+        minScale: PhotoViewComputedScale.contained,
+        heroAttributes: PhotoViewHeroAttributes(tag: tag),
+      ),
     );
   }
 }

--- a/packages/dart_flutter_common/pubspec.lock
+++ b/packages/dart_flutter_common/pubspec.lock
@@ -368,6 +368,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/packages/dart_flutter_common/pubspec.yaml
+++ b/packages/dart_flutter_common/pubspec.yaml
@@ -1,10 +1,10 @@
 name: dart_flutter_common
 description: MOTTAI app Dart and Flutter common.
-publish_to: 'none'
+publish_to: "none"
 version: 0.0.1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   cached_network_image: ^3.2.3
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   image_picker: ^1.0.1
   intl: 0.18.1
+  photo_view: ^0.14.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/mottai_flutter_app/pubspec.lock
+++ b/packages/mottai_flutter_app/pubspec.lock
@@ -1118,6 +1118,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  photo_view:
+    dependency: transitive
+    description:
+      name: photo_view
+      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue
- #78 

close #78

## 説明
画像詳細ビューで最大まで拡大後、縮小ができないバグの修正。
InteractiveViewerを使用して画像詳細画面を表示していたが、ジェスチャーの反応範囲は画像のサイズが変わっても変わらないため、縮小ができないように感じてしまう。
ジェスチャーの範囲が画面全体で作成されているphoto_viewを使用して当画面を作成しなおした。

## UI
![mottai_issue78](https://github.com/KosukeSaigusa/mottai-flutter-app/assets/56541594/006fe063-7e64-4fae-89b0-3809abbcd9f2)


## その他
photo_viewは画面全体を覆うウィジェットのため、以前までつけていた画像外をタップすると画面が閉じる処理は削除しています。

## チェックリスト

- [x] PR の冒頭に関連する Issue 番号を記載しましたか？
- [ ] 本 PR の変更に関して、エディタや IDE で意図しない警告は増えていませんか？（lint 警告やタイポなど）
- [x] Issue の完了の定義は満たせていますか？
- [ ] 当該 Issue のスレッドで、レビュワーにレビュー依頼をしましたか？
