### PR TITLE
#108 仕事詳細画面のリンクをWebLinkウィジェットに置き換え

### DIFF
--- a/packages/dart_flutter_common/lib/src/widgets/web_link.dart
+++ b/packages/dart_flutter_common/lib/src/widgets/web_link.dart
@@ -17,6 +17,7 @@ class WebLink extends StatelessWidget {
     this.textStyle,
     this.linkStyle,
     this.onFailLaunch,
+    this.maxLines,
     super.key,
   });
 
@@ -34,6 +35,9 @@ class WebLink extends StatelessWidget {
   /// [urlText]のurl部分のスタイル
   final TextStyle? linkStyle;
 
+  /// urlの表示最大行数
+  final int? maxLines;
+
   /// リンク遷移が失敗した場合のコールバック
   final void Function(String url)? onFailLaunch;
 
@@ -48,6 +52,7 @@ class WebLink extends StatelessWidget {
           onFailLaunch?.call(link.url);
         }
       },
+      maxLines: maxLines,
       text: urlText,
       style: textStyle,
       linkStyle: linkStyle,

--- a/packages/mottai_flutter_app/lib/job/ui/job_detail.dart
+++ b/packages/mottai_flutter_app/lib/job/ui/job_detail.dart
@@ -184,12 +184,22 @@ class _JobDetail extends ConsumerWidget {
                     titleStyle: Theme.of(context).textTheme.headlineMedium,
                     sectionPadding: const EdgeInsets.only(bottom: 32),
                     content: Column(
-                      //TODO: リンクウィジェットにする。
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: readHost.urls
                           .map(
-                            (url) => Text(
-                              url,
-                              style: Theme.of(context).textTheme.bodyLarge,
+                            (url) => WebLink(
+                              urlText: url,
+                              mode: LaunchMode.externalApplication,
+                              linkStyle: Theme.of(context)
+                                  .textTheme
+                                  .bodyLarge
+                                  ?.copyWith(
+                                    color: Colors.blue,
+                                    decoration: TextDecoration.underline,
+                                    decorationColor: Colors.blue,
+                                  ),
+                              textStyle: Theme.of(context).textTheme.bodyLarge,
+                              maxLines: 1,
                             ),
                           )
                           .toList(),


### PR DESCRIPTION
## Issue
- #108

close #108

## 説明
仕事詳細ビューで表示するホストのURLをWebLinkウィジェットを使用して実装しました。
仕事詳細ビュー作成時は仮置きでTextウィジェットを表示していましたが、本チケットで置き換えしています。

リンク押下時は外部ブラウザを使用してリンクの内容を表示します。
これは複数のリンクを同時に開いた状態にできたり、リンクを開いた状態で保存しておけるメリットがあるためです。

また、リンクの表示を1行にするためにWebLinkウィジェットにmaxLines引数も追加をしています。

## UI
<img src="https://github.com/kosukesaigusa/mottai-flutter-app/assets/56541594/c8d73024-9306-49d8-af33-f1b14175f63c" height=500px>


## その他
なし

## チェックリスト

- [x] PR の冒頭に関連する Issue 番号を記載しましたか？
- [ ] 本 PR の変更に関して、エディタや IDE で意図しない警告は増えていませんか？（lint 警告やタイポなど）
- [x] Issue の完了の定義は満たせていますか？
- [ ] 当該 Issue のスレッドで、レビュワーにレビュー依頼をしましたか？
