### PR TITLE
Riverpod x Firestore の汎用的な Pagination の実装

### DIFF
--- a/packages/firebase_common/lib/src/firestore_documents/_export.dart
+++ b/packages/firebase_common/lib/src/firestore_documents/_export.dart
@@ -6,6 +6,7 @@ export 'host_location.dart';
 export 'in_review_config.dart';
 export 'job.dart';
 export 'read_status.dart';
+export 'review.dart';
 export 'sample_todo.dart';
 export 'user_fcm_token.dart';
 export 'user_social_login.dart';

--- a/packages/firebase_common/lib/src/firestore_repositories/_export.dart
+++ b/packages/firebase_common/lib/src/firestore_repositories/_export.dart
@@ -7,6 +7,7 @@ export 'host_location.dart';
 export 'in_review_config.dart';
 export 'job.dart';
 export 'read_status.dart';
+export 'review.dart';
 export 'sample_todo.dart';
 export 'user_social_login.dart';
 export 'worker.dart';

--- a/packages/firebase_common/lib/src/firestore_repositories/review.dart
+++ b/packages/firebase_common/lib/src/firestore_repositories/review.dart
@@ -1,0 +1,46 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../firestore_documents/_export.dart';
+
+class ReviewRepository {
+  /// [fetchReviewsWithIdCursor] メソッドにおいて、最後に読み込んだ
+  /// [QueryDocumentSnapshot] を保持するための [Map] 型の変数。
+  /// キーはそのドキュメント ID で、バリューが [QueryDocumentSnapshot].
+  final Map<String, QueryDocumentSnapshot<ReadReview>>
+      _lastFetchedQueryDocumentSnapshotCache = {};
+
+  /// まず [_lastFetchedQueryDocumentSnapshotCache] をクリアして、非 null の場合は、
+  /// 新しい [lastFetchedQueryDocumentSnapshot] をキャッシュに入れる。
+  void _updateLastReadQueryDocumentSnapshotCache(
+    QueryDocumentSnapshot<ReadReview>? lastFetchedQueryDocumentSnapshot,
+  ) {
+    _lastFetchedQueryDocumentSnapshotCache.clear();
+    if (lastFetchedQueryDocumentSnapshot != null) {
+      _lastFetchedQueryDocumentSnapshotCache[lastFetchedQueryDocumentSnapshot
+          .id] = lastFetchedQueryDocumentSnapshot;
+    }
+  }
+
+  /// [Review] を [limit] 件取得する。[lastFetchedId] が指定されている場合は、
+  /// そのドキュメント以降のドキュメントが得られる。
+  Future<List<ReadReview>> fetchReviewsWithIdCursor({
+    required int limit,
+    required String? lastFetchedId,
+  }) async {
+    var query = readReviewCollectionReference.orderBy(
+      'createdAt',
+      descending: true,
+    );
+    final qds = lastFetchedId == null
+        ? null
+        : _lastFetchedQueryDocumentSnapshotCache[lastFetchedId];
+    if (qds != null) {
+      query = query.startAfterDocument(qds);
+    }
+    final qs = await query.limit(limit).get();
+    final reviews = qs.docs.map((qds) => qds.data()).toList();
+    final lastFetchedQds = qs.docs.lastOrNull;
+    _updateLastReadQueryDocumentSnapshotCache(lastFetchedQds);
+    return reviews;
+  }
+}

--- a/packages/mottai_flutter_app/lib/firestore_repository.dart
+++ b/packages/mottai_flutter_app/lib/firestore_repository.dart
@@ -34,6 +34,9 @@ final jobRepositoryProvider =
 final readStatusRepositoryProvider =
     Provider.autoDispose<ReadStatusRepository>((_) => ReadStatusRepository());
 
+final reviewRepositoryProvider =
+    Provider.autoDispose<ReviewRepository>((_) => ReviewRepository());
+
 final sampleTodoRepositoryProvider =
     Provider.autoDispose<SampleTodoRepository>((_) => SampleTodoRepository());
 

--- a/packages/mottai_flutter_app/lib/pagination/firestore_pagination.dart
+++ b/packages/mottai_flutter_app/lib/pagination/firestore_pagination.dart
@@ -1,0 +1,88 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Firestore のパジネーションを行うための [StateNotifier].
+class FirestorePaginationStateNotifier<T>
+    extends StateNotifier<AsyncValue<List<T>>> {
+  FirestorePaginationStateNotifier({
+    required this.fetch,
+    required this.idFromObject,
+  }) : super(AsyncValue<List<T>>.data(const [])) {
+    _initialize();
+  }
+
+  /// データを取得する関数。
+  final Future<List<T>> Function(int perPage, String? lastFetchedId) fetch;
+
+  /// データから ID を取得する関数。
+  final String Function(T obj) idFromObject;
+
+  /// 最後に取得したデータの ID.
+  String? _lastFetchedId;
+
+  /// 取得処理中かどうか。
+  bool _isFetching = false;
+
+  /// 次のページがあるかどうか。
+  bool _hasNext = true;
+
+  /// リクエスト一回あたりの取得件数のデフォルト値。
+  static const _defaultPerPage = 10;
+
+  /// 取得処理中かどうか。
+  bool get isFetching => _isFetching;
+
+  /// 次のページがあるかどうか。
+  bool get hasNext => _hasNext;
+
+  /// 初期化処理。
+  Future<List<T>> _initialize({int perPage = _defaultPerPage}) async {
+    state = AsyncValue<List<T>>.loading();
+    _isFetching = true;
+    try {
+      final items = await fetch(perPage, null);
+      _hasNext = items.isNotEmpty;
+      state = AsyncValue<List<T>>.data(items);
+    } on Exception catch (e, s) {
+      state = AsyncValue<List<T>>.error(e, s);
+    } finally {
+      _isFetching = false;
+    }
+    return state.valueOrNull ?? [];
+  }
+
+  /// 次のページを取得する。
+  Future<void> fetchNext({int perPage = _defaultPerPage}) async {
+    final items = state;
+    if (_isFetching || items.isRefreshing || !items.hasValue || !_hasNext) {
+      return;
+    }
+    _isFetching = true;
+    try {
+      final result = await fetch(perPage, _lastFetchedId);
+      final newItems = [...state.valueOrNull ?? <T>[], ...result];
+      state = AsyncValue.data(newItems);
+      _hasNext = result.isNotEmpty;
+      _lastFetchedId = idFromObject(result.last);
+    } on Exception catch (e, stackTrace) {
+      state = AsyncValue<List<T>>.error(e, stackTrace);
+      return;
+    } finally {
+      _isFetching = false;
+    }
+  }
+
+  /// リフレッシュする。
+  Future<void> refresh({int perPage = _defaultPerPage}) async {
+    _isFetching = true;
+    _lastFetchedId = null;
+    try {
+      final items = await fetch(perPage, null);
+      _hasNext = items.isNotEmpty;
+      state = AsyncValue<List<T>>.data(items);
+    } on Exception catch (e, s) {
+      state = AsyncValue<List<T>>.error(e, s);
+    } finally {
+      _isFetching = false;
+    }
+  }
+}

--- a/packages/mottai_flutter_app/lib/pagination/ui/pagination_list_view.dart
+++ b/packages/mottai_flutter_app/lib/pagination/ui/pagination_list_view.dart
@@ -1,0 +1,133 @@
+import 'package:dart_flutter_common/dart_flutter_common.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../firestore_pagination.dart';
+
+/// [FirestorePaginationStateNotifier] を使用した無限スクロールの [ListView] UI.
+class FirestorePaginationListView<T> extends ConsumerWidget {
+  const FirestorePaginationListView({
+    required this.stateNotifierProvider,
+    required this.itemBuilder,
+    super.key,
+  });
+
+  /// [FirestorePaginationStateNotifier] を提供する [StateNotifierProvider]。
+  final AutoDisposeStateNotifierProvider<FirestorePaginationStateNotifier<T>,
+      AsyncValue<List<T>>> stateNotifierProvider;
+
+  /// [ListView.builder] で表示する各要素のビルダー関数。
+  final Widget Function(BuildContext, T) itemBuilder;
+
+  /// 画面の何割をスクロールした時点で次の _limit 件のメッセージを取得するか。
+  static const _scrollValueThreshold = 0.8;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(stateNotifierProvider);
+    final notifier = ref.watch(stateNotifierProvider.notifier);
+    return state.when(
+      data: (items) {
+        return Stack(
+          children: [
+            NotificationListener<ScrollNotification>(
+              onNotification: (notification) {
+                final metrics = notification.metrics;
+                final scrollValue = metrics.pixels / metrics.maxScrollExtent;
+                if (scrollValue > _scrollValueThreshold) {
+                  notifier.fetchNext();
+                }
+                return false;
+              },
+              child: ListView.builder(
+                itemCount: items.length,
+                itemBuilder: (context, index) {
+                  final item = items[index];
+                  return itemBuilder(context, item);
+                },
+              ),
+            ),
+            if (kDebugMode)
+              Positioned(
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: _DebugIndicator(notifier: notifier, items: items),
+                ),
+              ),
+          ],
+        );
+      },
+      error: (_, __) => const SizedBox(),
+      loading: () => const Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}
+
+// TODO: あとで消す。
+/// 開発時のみ表示する、無限スクロールのデバッグ用ウィジェット。
+class _DebugIndicator<T> extends ConsumerWidget {
+  const _DebugIndicator({
+    required this.notifier,
+    required this.items,
+  });
+
+  /// [FirestorePaginationStateNotifier]
+  final FirestorePaginationStateNotifier<T> notifier;
+
+  /// 取得したアイテム一覧。
+  final List<T> items;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 16, left: 16, right: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: const BoxDecoration(
+        color: Colors.black38,
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'デバッグウィンドウ',
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall!
+                .copyWith(color: Colors.white),
+          ),
+          const Gap(4),
+          Text(
+            '取得件数：${items.length.withComma} 件',
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall!
+                .copyWith(color: Colors.white),
+          ),
+          Text(
+            '取得中？：${notifier.isFetching}',
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall!
+                .copyWith(color: Colors.white),
+          ),
+          Text(
+            'まだ取得できる？：${notifier.hasNext}',
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall!
+                .copyWith(color: Colors.white),
+          ),
+          const Gap(8),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/mottai_flutter_app/lib/review/review.dart
+++ b/packages/mottai_flutter_app/lib/review/review.dart
@@ -1,0 +1,20 @@
+import 'package:firebase_common/firebase_common.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../firestore_repository.dart';
+import '../pagination/firestore_pagination.dart';
+
+const _limit = 10;
+
+/// [Review] を [_limit] 件ずつパジネーションで取得する [StateNotifierProvider].
+final reviewsStateNotifierProvider = StateNotifierProvider.autoDispose<
+    FirestorePaginationStateNotifier<ReadReview>, AsyncValue<List<ReadReview>>>(
+  (ref) => FirestorePaginationStateNotifier<ReadReview>(
+    fetch: (perPage, lastFetchedId) =>
+        ref.watch(reviewRepositoryProvider).fetchReviewsWithIdCursor(
+              limit: _limit,
+              lastFetchedId: lastFetchedId,
+            ),
+    idFromObject: (obj) => obj.reviewId,
+  ),
+);

--- a/packages/mottai_flutter_app/lib/review/ui/reviews.dart
+++ b/packages/mottai_flutter_app/lib/review/ui/reviews.dart
@@ -1,5 +1,9 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:firebase_common/firebase_common.dart';
 import 'package:flutter/material.dart';
+
+import '../../pagination/ui/pagination_list_view.dart';
+import '../review.dart';
 
 /// レビュー一覧画面。
 @RoutePage()
@@ -14,6 +18,14 @@ class ReviewsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox();
+    return FirestorePaginationListView<ReadReview>(
+      stateNotifierProvider: reviewsStateNotifierProvider,
+      itemBuilder: (context, review) =>
+          // TODO: 後で MaterialVerticalCard に書き換える。
+          ListTile(
+        title: Text(review.title),
+        subtitle: Text(review.content),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Issue

close #141

## 説明

Riverpod x Firestore の汎用的な Pagination の実装をしました。

それを用いて感想一覧ページを実装しました。`MaterialVerticalCard` のコンポーネントができたら表示内容を差し替える旨を TODO コメントで書いたとおりです。

## UI

## その他

その他に言及したいことがあれば書いてください。

## チェックリスト

- [x] PR の冒頭に関連する Issue 番号を記載しましたか？
- [x] 本 PR の変更に関して、エディタや IDE で意図しない警告は増えていませんか？（lint 警告やタイポなど）
- [x] Issue の完了の定義は満たせていますか？
- [x] 当該 Issue のスレッドで、レビュワーにレビュー依頼をしましたか？
